### PR TITLE
Add Tokyo region for EFS option

### DIFF
--- a/templates/sap-s4hana-aas.template
+++ b/templates/sap-s4hana-aas.template
@@ -1536,6 +1536,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],

--- a/templates/sap-s4hana-ascs-HA.template
+++ b/templates/sap-s4hana-ascs-HA.template
@@ -2957,6 +2957,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],

--- a/templates/sap-s4hana-ascs.template
+++ b/templates/sap-s4hana-ascs.template
@@ -2945,6 +2945,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],

--- a/templates/sap-s4hana-exg-vpc-HA.template
+++ b/templates/sap-s4hana-exg-vpc-HA.template
@@ -2877,6 +2877,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],

--- a/templates/sap-s4hana-exg-vpc.template
+++ b/templates/sap-s4hana-exg-vpc.template
@@ -3085,6 +3085,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],

--- a/templates/sap-s4hana-new-vpc-HA.template
+++ b/templates/sap-s4hana-new-vpc-HA.template
@@ -2109,7 +2109,7 @@
         "Assertions": [{
             "Assert": {
                 "Fn::Contains": [
-                    ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-southeast-2"], {
+                    ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-northeast-1", "ap-southeast-1", "ap-southeast-2"], {
                         "Ref": "AWS::Region"
                     }
                 ]

--- a/templates/sap-s4hana-new-vpc.template
+++ b/templates/sap-s4hana-new-vpc.template
@@ -2286,7 +2286,7 @@
         "Assertions": [{
             "Assert": {
                 "Fn::Contains": [
-                    ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-southeast-2"], {
+                    ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-northeast-1", "ap-southeast-1", "ap-southeast-2"], {
                         "Ref": "AWS::Region"
                     }
                 ]

--- a/templates/sap-s4hana-pas.template
+++ b/templates/sap-s4hana-pas.template
@@ -1851,6 +1851,7 @@
                                 "us-west-2",
                                 "eu-west-1",
                                 "eu-central-1",
+                                "ap-northeast-1",
                                 "ap-southeast-1",
                                 "ap-southeast-2"
                             ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Amazon EFS is available in Tokyo region, ap-northeast-1. I add parameter in CloudFormation template. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
